### PR TITLE
bug about auto.js

### DIFF
--- a/source/auto.js
+++ b/source/auto.js
@@ -140,6 +140,9 @@ module.exports = async (input, options, callback) => {
 			}
 
 			return new Http2ClientRequest(options, callback);
+		} else {
+			// I am not sure if I should run the following code,it's protocol is still "https"
+			return https.request(options, callback)
 		}
 	}
 


### PR DESCRIPTION
When I initiate a request with a protocol of "https"（like 'https://www.baidu.com '）, An error occurred：
   Protocol "https:" not supported. Expected "http:"