### PR TITLE
add back support for older node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "source",
 	"types": "index.d.ts",
 	"engines": {
-		"node": ">=15.10.0"
+		"node": "^12.20.1 || ^14.0.0  || ^15.10.0"
 	},
 	"scripts": {
 		"test": "xo && nyc --reporter=lcovonly --reporter=text --reporter=html ava && tsd"


### PR DESCRIPTION
Looks like this was changed in https://github.com/szmarczak/http2-wrapper/commit/3400e6fdac3aba543c0a4d8c39f2f4d6fb26eca4

And in https://github.com/szmarczak/http2-wrapper/commit/49cf5e88cee78e115b5c3e60e91e75d25a1b94ad#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

Our build pulled in the latest version this morning and we arent alone 
fixes #63 


This PR should buy us some time to identify why that was. 

WIP: still checking to see if the code still works on older versions for now so a bit more time should be save to permit other node versions.