### PR TITLE
Removed ? typo from auto.js fixing a syntax error.

### DIFF
--- a/source/auto.js
+++ b/source/auto.js
@@ -124,7 +124,7 @@ module.exports = async (input, options, callback) => {
 
 	options.host = options.hostname || options.host || 'localhost';
 	options.session = options.tlsSession;
-	options.servername = options.servername || calculateServerName(options.headers?.host || options.host);
+	options.servername = options.servername || calculateServerName(options.headers.host || options.host);
 	options.port = options.port || (isHttps ? 443 : 80);
 	options._defaultAgent = isHttps ? https.globalAgent : http.globalAgent;
 


### PR DESCRIPTION
I think there was a typo in one of the recent commits.  It looks like a ? snuck in there : ).  This just deletes it.  Thanks for the great repos!