### PR TITLE
Skip HTTP/2 headers when making a HTTP/1 request

### DIFF
--- a/source/auto.js
+++ b/source/auto.js
@@ -198,6 +198,20 @@ module.exports = async (input, options, callback) => {
 		options.agent = agent.http;
 	}
 
+	// If we're sending HTTP/1.1, handle any explicitly set H2 headers in the options:
+	if (options.headers) {
+		// :authority is equivalent to the http/1.1 host header
+		if (options.headers[':authority'] && !options.headers.host) {
+			options.headers.host = options.headers[':authority'];
+			delete options.headers[':authority'];
+		}
+
+		// All other H2 headers are represented in the request-line, separate to headers
+		delete options.headers[':method'];
+		delete options.headers[':scheme'];
+		delete options.headers[':path'];
+	}
+
 	return delayAsyncDestroy(http.request(options, callback));
 };
 

--- a/source/auto.js
+++ b/source/auto.js
@@ -201,8 +201,11 @@ module.exports = async (input, options, callback) => {
 	// If we're sending HTTP/1.1, handle any explicitly set H2 headers in the options:
 	if (options.headers) {
 		// :authority is equivalent to the http/1.1 host header
-		if (options.headers[':authority'] && !options.headers.host) {
-			options.headers.host = options.headers[':authority'];
+		if (options.headers[':authority']) {
+			if (!options.headers.host) {
+				options.headers.host = options.headers[':authority'];
+			}
+
 			delete options.headers[':authority'];
 		}
 

--- a/test/auto.js
+++ b/test/auto.js
@@ -118,6 +118,26 @@ test('https', async t => {
 	t.is(data, 'http/1.1');
 });
 
+test('https with http2 headers', async t => {
+	const request = await http2.auto({
+		protocol: 'https:',
+		hostname: 'localhost',
+		port: h2s.address().port,
+		ALPNProtocols: ['http/1.1'],
+		headers: {
+			':method': 'GET',
+			':scheme': 'https',
+			':authority': `localhost:${h2s.address().port}`,
+			':path': '/'
+		}
+	});
+	request.end();
+
+	const response = await pEvent(request, 'response');
+	const data = await getStream(response);
+	t.is(data, 'http/1.1');
+});
+
 test('https agent', async t => {
 	const agent = new https.Agent();
 


### PR DESCRIPTION
Fixes #98 as suggested in that issue, effectively following the RFC recommendations.