### PR TITLE
Disable ESLint error in test TS type code

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,6 +5,8 @@ import http from 'node:http';
 import https from 'node:https';
 import {expectType, expectAssignable} from 'tsd';
 import QuickLRU from 'quick-lru';
+
+// eslint-disable-next-line import/extensions
 import http2 from '.';
 
 expectType<http2.Agent>(http2.globalAgent);


### PR DESCRIPTION
The tests currently fail on master.

That seems to be because there's been an unexpected change in a dependency, so that `.` is now considered to be a bare name that's missing an extension. That's not correct - we want to import the whole package here in this case. Since this is only typing test code, it seems clearest to just disable the rule for this one line here for now.